### PR TITLE
Simply dock layout restoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,14 @@ __pycache__/
 .ipynb_checkpoints/
 .pytest_cache/
 *.egg-info
+*.tgz
 *.tsbuildinfo
+/lab/
+build/
 dask-worker-space/
 dist/
 envs/
 lib/
 node_modules/
-Untitled*.ipynb
-/lab/
+untitled*
+Untitled*

--- a/src/ts/wxyz-lab/src/widgets/_dock.ts
+++ b/src/ts/wxyz-lab/src/widgets/_dock.ts
@@ -98,8 +98,18 @@ export class JupyterPhosphorDockPanelWidget extends DockPanel {
 
   onLayoutChanged() {
     let layout = this.saveLayout();
-    this._view.model.set('dock_layout', this.areaToJWidgets(layout.main));
-    this._view.touch();
+    let dockLayout: any;
+
+    try {
+      dockLayout = this.areaToJWidgets(layout.main);
+    } catch (err) {
+      console.warn('Could not read dock layout', err);
+    }
+
+    if (dockLayout != null) {
+      this._view.model.set('dock_layout', dockLayout);
+      this._view.touch();
+    }
   }
 
   areaToJWidgets(area: DockLayout.AreaConfig): object {

--- a/src/ts/wxyz-lab/src/widgets/dock.ts
+++ b/src/ts/wxyz-lab/src/widgets/dock.ts
@@ -52,11 +52,13 @@ export class DockBoxView extends BoxView {
       return;
     }
 
+    const originalLayout = this.model.get('dock_layout');
+
     // handle initial child readiness for `dock_layout`
     Promise.all(this.children_views.views)
       .then(async () => {
-        if (this.model.get('dock_layout')) {
-          await (this.pWidget as any).onLayoutModelChanged();
+        if (originalLayout != null) {
+          await (this.pWidget as any).onLayoutModelChanged(originalLayout);
         }
         this._childrenInitialized = true;
       })
@@ -67,7 +69,6 @@ export class DockBoxView extends BoxView {
 
   _createElement(tagName: string) {
     this.pWidget = new JupyterPhosphorDockPanelWidget({ view: this }) as any;
-    this.pWidget.node.title = 'Shift+Click to view full screen';
     this.pWidget.node.addEventListener('click', (evt: MouseEvent) => {
       if (evt.shiftKey) {
         const anyful = screenfull as any;


### PR DESCRIPTION
This simplifies some behavior relating to `dock_layout`. 

Notably, and in contrast to #24, it:
- rounds off the relative child sizes (it will be off by pixels if your screen is over 10k) to avoid thrashing with multiple instances on the screen
- removes some fragile timer-based checks, instead just using an initial `dock_layout` if provided after all the children render

Like #24, it:
- removes the ctrl+click title for DockBox