### PR TITLE
Check Lab 3.0.5, Preflight release

### DIFF
--- a/.github/locks/conda.binder.linux-64-3.8-3.0.lock
+++ b/.github/locks/conda.binder.linux-64-3.8-3.0.lock
@@ -1,5 +1,5 @@
 # platform: linux-64
-# env_hash: b25c4dc73e6e96f23cde8bb1710b4df3439acdba749d66190b8bdb7fa9775fb8
+# env_hash: d28eb037c642d6981e298e459fbc6ce3966ef267ae2ce36f570836c798027dc1
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
 https://conda.anaconda.org/conda-forge/linux-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#23b8f98a355030331f40d0245492f715
@@ -233,7 +233,7 @@ https://conda.anaconda.org/conda-forge/noarch/certipy-0.1.3-py_0.tar.bz2#2348671
 https://conda.anaconda.org/conda-forge/noarch/jupyter_telemetry-0.1.0-pyhd8ed1ab_1.tar.bz2#bb9ebdb6d5aa2622484aff1faceee181
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/linux-64/keyring-21.8.0-py38h578d9bd_0.tar.bz2#0358a7702293487e431c89625d416c24
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
 https://conda.anaconda.org/conda-forge/noarch/readme_renderer-27.0-pyh9f0ad1d_0.tar.bz2#38446dff7f69efd3fab98ab4dc68c0c8
 https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-0.24.0-py38h658cfdd_0.tar.bz2#0f511b4166fb52772afb9b05fb695f83
 https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.2-pyhd8ed1ab_0.tar.bz2#8bb930d172961c9ba9ffd6e10a64b844

--- a/.github/locks/conda.binder.linux-64-3.8-3.0.lock
+++ b/.github/locks/conda.binder.linux-64-3.8-3.0.lock
@@ -1,5 +1,5 @@
 # platform: linux-64
-# env_hash: d28eb037c642d6981e298e459fbc6ce3966ef267ae2ce36f570836c798027dc1
+# env_hash: e437327fab2be9c8c11e64f05f6d387d7ba9bfa362f4f1506e8c2aad26a55b14
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
 https://conda.anaconda.org/conda-forge/linux-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#23b8f98a355030331f40d0245492f715
@@ -283,4 +283,3 @@ https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4
 https://conda.anaconda.org/conda-forge/noarch/ipylab-0.4.1-pyhd8ed1ab_0.tar.bz2#c48a8785da83bbddfc2e5e9173a656a1
 https://conda.anaconda.org/conda-forge/noarch/ipympl-0.6.2-pyhd8ed1ab_0.tar.bz2#fd94fe44ff7117af3bdc4b98098f8111
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-classic-0.1.2-pyhd8ed1ab_0.tar.bz2#1ba9135530eba24ef877abdeb5b00620

--- a/.github/locks/conda.binder.linux-64-3.8-3.0.lock
+++ b/.github/locks/conda.binder.linux-64-3.8-3.0.lock
@@ -60,7 +60,7 @@ https://conda.anaconda.org/conda-forge/linux-64/readline-8.0-he28a2e2_2.tar.bz2#
 https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.10-h21135ba_1.tar.bz2#c647f70aa7e3d4cc4e029cc1c9a99953
 https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.3-h58526e2_3.tar.bz2#6272fa8d98bd79c7978da0f7d2bb28da
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.8-ha95c52a_1.tar.bz2#ed4dbbaf7d81423678632bf982f45ede
-https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.4-h7ca028e_0.tar.bz2#1e6bf409916fdf455a5bb8627b626285
+https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.4-h0708190_1.tar.bz2#4a06f2ac2e5bfae7b6b245171c3f07aa
 https://conda.anaconda.org/conda-forge/linux-64/krb5-1.17.2-h926e7f8_0.tar.bz2#926325c11478d6e781e76072c117763b
 https://conda.anaconda.org/conda-forge/linux-64/libglib-2.66.4-h164308a_1.tar.bz2#d320eec766d1f41b94b75a09e020ed32
 https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.2.0-hdc55705_0.tar.bz2#f1406324f1d02fa26447a0a0f2dd0107
@@ -195,7 +195,7 @@ https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2021.1.11-py38h60827
 https://conda.anaconda.org/conda-forge/noarch/imageio-2.9.0-py_0.tar.bz2#62ad9e579278e777d4abaa8c9312b6a7
 https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-3.4.0-hd8ed1ab_0.tar.bz2#6d962cade0658bb1040a3e994add14e0
 https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-4.7.0-py38h578d9bd_0.tar.bz2#aa83f54189c3289055f7811fbabc2d12
-https://conda.anaconda.org/conda-forge/noarch/mako-1.1.3-pyh9f0ad1d_0.tar.bz2#7c87121b0244cf6a1f44a1df12a846ea
+https://conda.anaconda.org/conda-forge/noarch/mako-1.1.4-pyh44b312d_0.tar.bz2#1b618b99d151e88ba0fabff9fa2b2d0b
 https://conda.anaconda.org/conda-forge/noarch/markdown-3.3.3-pyh9f0ad1d_0.tar.bz2#59bb2a2c29091c3a243701e26f6f1f5e
 https://conda.anaconda.org/conda-forge/linux-64/pandas-1.2.0-py38h51da96c_1.tar.bz2#b5e96f13c09c1d40ae15878dd019c02b
 https://conda.anaconda.org/conda-forge/linux-64/pytorch-1.7.1-cpu_py38h36eccb8_1.tar.bz2#cf9896b22daae9c41a8fa8bf576ac804
@@ -233,7 +233,7 @@ https://conda.anaconda.org/conda-forge/noarch/certipy-0.1.3-py_0.tar.bz2#2348671
 https://conda.anaconda.org/conda-forge/noarch/jupyter_telemetry-0.1.0-pyhd8ed1ab_1.tar.bz2#bb9ebdb6d5aa2622484aff1faceee181
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/linux-64/keyring-21.8.0-py38h578d9bd_0.tar.bz2#0358a7702293487e431c89625d416c24
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
 https://conda.anaconda.org/conda-forge/noarch/readme_renderer-27.0-pyh9f0ad1d_0.tar.bz2#38446dff7f69efd3fab98ab4dc68c0c8
 https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-0.24.0-py38h658cfdd_0.tar.bz2#0f511b4166fb52772afb9b05fb695f83
 https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.2-pyhd8ed1ab_0.tar.bz2#8bb930d172961c9ba9ffd6e10a64b844
@@ -277,7 +277,7 @@ https://conda.anaconda.org/conda-forge/noarch/nbresuse-0.4.0-pyhd8ed1ab_0.tar.bz
 https://conda.anaconda.org/conda-forge/linux-64/widgetsnbextension-3.5.1-py38h578d9bd_4.tar.bz2#beb8a105545382ba138c81c926289b5b
 https://conda.anaconda.org/conda-forge/noarch/hvplot-0.7.0-pyhd3deb0d_0.tar.bz2#b2e8747e6b00559ed461c979766a2ed7
 https://conda.anaconda.org/conda-forge/noarch/ipywidgets-7.6.3-pyhd3deb0d_0.tar.bz2#536a9ed6d9e740f2b83d1a3c388e4388
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.4-pyhd8ed1ab_0.tar.bz2#f196ddf31157a9d42e724fde26790330
+https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.5-pyhd8ed1ab_0.tar.bz2#4824b73d683d4efb2f3dfb352b24544a
 https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.21-pyhd8ed1ab_0.tar.bz2#1f804e7d3cd16071e4c4e81567d529ce
 https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab_0.tar.bz2#912033f0b7f96ecb2bb73a24333541e2
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4

--- a/.github/locks/conda.docs.linux-64-3.8-3.0.lock
+++ b/.github/locks/conda.docs.linux-64-3.8-3.0.lock
@@ -1,5 +1,5 @@
 # platform: linux-64
-# env_hash: b312df30a54288cf2ff79b322af68ce376c31a87b869040baa2c909c31ee07d2
+# env_hash: 91fecfa70084a551d29758dfcf1b9548cd1f7894d701081959d2b4a056bd84f0
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
 https://conda.anaconda.org/conda-forge/linux-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#23b8f98a355030331f40d0245492f715
@@ -371,5 +371,4 @@ https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.ta
 https://conda.anaconda.org/conda-forge/noarch/ipylab-0.4.1-pyhd8ed1ab_0.tar.bz2#c48a8785da83bbddfc2e5e9173a656a1
 https://conda.anaconda.org/conda-forge/noarch/ipympl-0.6.2-pyhd8ed1ab_0.tar.bz2#fd94fe44ff7117af3bdc4b98098f8111
 https://conda.anaconda.org/conda-forge/noarch/jupyter-sphinx-0.3.2-py_0.tar.bz2#9ae5148b076ddba22552ddb57a4c22ee
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-classic-0.1.2-pyhd8ed1ab_0.tar.bz2#1ba9135530eba24ef877abdeb5b00620
 https://conda.anaconda.org/conda-forge/noarch/myst-nb-0.10.1-py_0.tar.bz2#7e0b1188f876c469a6eaf31f5798233a

--- a/.github/locks/conda.docs.linux-64-3.8-3.0.lock
+++ b/.github/locks/conda.docs.linux-64-3.8-3.0.lock
@@ -84,7 +84,7 @@ https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.10-h21135ba_1.tar.bz2#c64
 https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.3-h84519dc_1000.tar.bz2#56cc238b81624db9e3e36b2b6a482cc1
 https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.3-h58526e2_3.tar.bz2#6272fa8d98bd79c7978da0f7d2bb28da
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.8-ha95c52a_1.tar.bz2#ed4dbbaf7d81423678632bf982f45ede
-https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.4-h7ca028e_0.tar.bz2#1e6bf409916fdf455a5bb8627b626285
+https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.4-h0708190_1.tar.bz2#4a06f2ac2e5bfae7b6b245171c3f07aa
 https://conda.anaconda.org/conda-forge/linux-64/hunspell-1.7.0-h68659b9_1001.tar.bz2#598373baf2b216b5418846df7cceeb13
 https://conda.anaconda.org/conda-forge/linux-64/krb5-1.17.2-h926e7f8_0.tar.bz2#926325c11478d6e781e76072c117763b
 https://conda.anaconda.org/conda-forge/linux-64/libglib-2.66.4-h164308a_1.tar.bz2#d320eec766d1f41b94b75a09e020ed32
@@ -92,7 +92,7 @@ https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.2.0-hdc55705_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.33-h15afd5d_2.tar.bz2#811bb9f5437fc6a04ba30d10f7a0c3eb
 https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.34.0-h74cdb3f_0.tar.bz2#0a83e21e8c1929cc9a1e21ebb2459fc5
 https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.6.12-h516909a_0.tar.bz2#cdea71c3e27611e012419faea02c56bd
-https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.13.1-h736d332_1003.tar.bz2#b334e3822a600cc536b674af4b988815
+https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.13.1-hba837de_1004.tar.bz2#bbe61e6ae39440dd101d77bf80ffc2cd
 https://conda.anaconda.org/conda-forge/linux-64/fossil-2.13-h99f322b_0.tar.bz2#51d514f9b29ae032e96aaaca37834437
 https://conda.anaconda.org/conda-forge/noarch/hunspell-en-2020.06.01-1.tar.bz2#16da4058944a75c95810ab46418f5812
 https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.11-hcbb858e_1.tar.bz2#89fcd6a52a99f3e255989f8cfc80c489
@@ -305,7 +305,7 @@ https://conda.anaconda.org/conda-forge/noarch/xarray-0.16.2-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.2.3-py38h578d9bd_0.tar.bz2#53acd76e57c900918afe81910f471167
 https://conda.anaconda.org/conda-forge/linux-64/click-completion-0.5.2-py38h32f6830_1.tar.bz2#e33e94fbf0c249e076d4b09082962e87
 https://conda.anaconda.org/conda-forge/linux-64/keyring-21.8.0-py38h578d9bd_0.tar.bz2#0358a7702293487e431c89625d416c24
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
 https://conda.anaconda.org/conda-forge/linux-64/pylint-2.6.0-py38h32f6830_1.tar.bz2#1a653a6095a070fd5b908220e966e551
 https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-2.2.0-pyhd8ed1ab_0.tar.bz2#b4c969906732870a2e52208958730d6c
 https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.16-pyhd3deb0d_1.tar.bz2#0bddaf14a6d50e015ac6e492be207b4f
@@ -321,7 +321,7 @@ https://conda.anaconda.org/conda-forge/linux-64/py-xgboost-1.3.0-py38h578d9bd_1.
 https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.1-pyhd3deb0d_0.tar.bz2#f727bc4b55f5a7b48cec33be3a21b3ab
 https://conda.anaconda.org/conda-forge/noarch/requests-2.25.1-pyhd3deb0d_0.tar.bz2#ae687aba31a1c400192a86a2e993ffdc
 https://conda.anaconda.org/conda-forge/noarch/scikit-mdr-0.4.4-py_1.tar.bz2#9ce428157b9f31e2d1f4e48b93556159
-https://conda.anaconda.org/conda-forge/linux-64/selenium-3.141.0-py38h1e0a361_1002.tar.bz2#c5407c16d93e0e81d7113caf15d079b7
+https://conda.anaconda.org/conda-forge/linux-64/selenium-3.141.0-py38h497a2fe_1002.tar.bz2#5f732f64b2873cfc34a825c38faaeca0
 https://conda.anaconda.org/conda-forge/noarch/skrebate-0.61-pyh9f0ad1d_0.tar.bz2#a75047ba4c76ae7d75fb9b44f9b1a705
 https://conda.anaconda.org/conda-forge/noarch/yellowbrick-1.2-pyh9f0ad1d_0.tar.bz2#3eef320f403216b68eba3a6424f96b9c
 https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2#7c9c5295a0499bf56bbf084578618af5
@@ -364,7 +364,7 @@ https://conda.anaconda.org/conda-forge/linux-64/widgetsnbextension-3.5.1-py38h57
 https://conda.anaconda.org/conda-forge/noarch/hvplot-0.7.0-pyhd3deb0d_0.tar.bz2#b2e8747e6b00559ed461c979766a2ed7
 https://conda.anaconda.org/conda-forge/noarch/ipywidgets-7.6.3-pyhd3deb0d_0.tar.bz2#536a9ed6d9e740f2b83d1a3c388e4388
 https://conda.anaconda.org/conda-forge/noarch/jupyter-cache-0.4.1-py_0.tar.bz2#b326be185f02af10136ef8eb9fd3e2dc
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.4-pyhd8ed1ab_0.tar.bz2#f196ddf31157a9d42e724fde26790330
+https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.5-pyhd8ed1ab_0.tar.bz2#4824b73d683d4efb2f3dfb352b24544a
 https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.21-pyhd8ed1ab_0.tar.bz2#1f804e7d3cd16071e4c4e81567d529ce
 https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab_0.tar.bz2#912033f0b7f96ecb2bb73a24333541e2
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4

--- a/.github/locks/conda.docs.linux-64-3.8-3.0.lock
+++ b/.github/locks/conda.docs.linux-64-3.8-3.0.lock
@@ -1,5 +1,5 @@
 # platform: linux-64
-# env_hash: a7fec1771860f508950121e27e7b581cf2f99cacef50c9f46d476f0f2780c8ac
+# env_hash: b312df30a54288cf2ff79b322af68ce376c31a87b869040baa2c909c31ee07d2
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
 https://conda.anaconda.org/conda-forge/linux-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#23b8f98a355030331f40d0245492f715
@@ -305,7 +305,7 @@ https://conda.anaconda.org/conda-forge/noarch/xarray-0.16.2-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.2.3-py38h578d9bd_0.tar.bz2#53acd76e57c900918afe81910f471167
 https://conda.anaconda.org/conda-forge/linux-64/click-completion-0.5.2-py38h32f6830_1.tar.bz2#e33e94fbf0c249e076d4b09082962e87
 https://conda.anaconda.org/conda-forge/linux-64/keyring-21.8.0-py38h578d9bd_0.tar.bz2#0358a7702293487e431c89625d416c24
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
 https://conda.anaconda.org/conda-forge/linux-64/pylint-2.6.0-py38h32f6830_1.tar.bz2#1a653a6095a070fd5b908220e966e551
 https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-2.2.0-pyhd8ed1ab_0.tar.bz2#b4c969906732870a2e52208958730d6c
 https://conda.anaconda.org/conda-forge/noarch/python-graphviz-0.16-pyhd3deb0d_1.tar.bz2#0bddaf14a6d50e015ac6e492be207b4f

--- a/.github/locks/conda.test.linux-64-3.6-3.0.lock
+++ b/.github/locks/conda.test.linux-64-3.6-3.0.lock
@@ -1,5 +1,5 @@
 # platform: linux-64
-# env_hash: 0e7762faf8729a0c3e6fb874bb8470e444cdc3f3390e3e107b5a6f122cce468c
+# env_hash: da670176dd0c58d44a5bc953b2c925ca387ef09cd8f323ba5e34b456cddb66cd
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
 https://conda.anaconda.org/conda-forge/linux-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#23b8f98a355030331f40d0245492f715
@@ -248,7 +248,7 @@ https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.2.3-py36h5fab9bb_0.tar.b
 https://conda.anaconda.org/conda-forge/noarch/importnb-0.7.0-pyhd8ed1ab_0.tar.bz2#73d3885a2fc883f4d19bc7b70baa37d2
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/linux-64/keyring-21.8.0-py36h5fab9bb_0.tar.bz2#699881f67874c81dcffc91ba31fd70e0
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
 https://conda.anaconda.org/conda-forge/linux-64/pylint-2.6.0-py36h9f0ad1d_1.tar.bz2#58b667768ed6e546d707aa02deeaf344
 https://conda.anaconda.org/conda-forge/linux-64/pytest-6.2.1-py36h5fab9bb_1.tar.bz2#cf7e4966b7d8e85aa3529bfb3c733ffc
 https://conda.anaconda.org/conda-forge/noarch/readme_renderer-27.0-pyh9f0ad1d_0.tar.bz2#38446dff7f69efd3fab98ab4dc68c0c8

--- a/.github/locks/conda.test.linux-64-3.6-3.0.lock
+++ b/.github/locks/conda.test.linux-64-3.6-3.0.lock
@@ -1,5 +1,5 @@
 # platform: linux-64
-# env_hash: da670176dd0c58d44a5bc953b2c925ca387ef09cd8f323ba5e34b456cddb66cd
+# env_hash: cf05adfcf743a10540228859bd4c0cac574d8068b2ae1b6fec1c18e2e2c9e2f0
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
 https://conda.anaconda.org/conda-forge/linux-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#23b8f98a355030331f40d0245492f715
@@ -301,4 +301,3 @@ https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4
 https://conda.anaconda.org/conda-forge/noarch/ipylab-0.4.1-pyhd8ed1ab_0.tar.bz2#c48a8785da83bbddfc2e5e9173a656a1
 https://conda.anaconda.org/conda-forge/noarch/ipympl-0.6.2-pyhd8ed1ab_0.tar.bz2#fd94fe44ff7117af3bdc4b98098f8111
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-classic-0.1.2-pyhd8ed1ab_0.tar.bz2#1ba9135530eba24ef877abdeb5b00620

--- a/.github/locks/conda.test.linux-64-3.6-3.0.lock
+++ b/.github/locks/conda.test.linux-64-3.6-3.0.lock
@@ -61,7 +61,7 @@ https://conda.anaconda.org/conda-forge/linux-64/readline-8.0-he28a2e2_2.tar.bz2#
 https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.10-h21135ba_1.tar.bz2#c647f70aa7e3d4cc4e029cc1c9a99953
 https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.3-h58526e2_3.tar.bz2#6272fa8d98bd79c7978da0f7d2bb28da
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.8-hdf46e1d_0.tar.bz2#9e4943915c2bc43144da348d0c1b1e6b
-https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.4-h7ca028e_0.tar.bz2#1e6bf409916fdf455a5bb8627b626285
+https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.4-h0708190_1.tar.bz2#4a06f2ac2e5bfae7b6b245171c3f07aa
 https://conda.anaconda.org/conda-forge/linux-64/krb5-1.17.2-h926e7f8_0.tar.bz2#926325c11478d6e781e76072c117763b
 https://conda.anaconda.org/conda-forge/linux-64/libglib-2.66.4-h164308a_1.tar.bz2#d320eec766d1f41b94b75a09e020ed32
 https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.2.0-hdc55705_0.tar.bz2#f1406324f1d02fa26447a0a0f2dd0107
@@ -248,7 +248,7 @@ https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.2.3-py36h5fab9bb_0.tar.b
 https://conda.anaconda.org/conda-forge/noarch/importnb-0.7.0-pyhd8ed1ab_0.tar.bz2#73d3885a2fc883f4d19bc7b70baa37d2
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/linux-64/keyring-21.8.0-py36h5fab9bb_0.tar.bz2#699881f67874c81dcffc91ba31fd70e0
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
 https://conda.anaconda.org/conda-forge/linux-64/pylint-2.6.0-py36h9f0ad1d_1.tar.bz2#58b667768ed6e546d707aa02deeaf344
 https://conda.anaconda.org/conda-forge/linux-64/pytest-6.2.1-py36h5fab9bb_1.tar.bz2#cf7e4966b7d8e85aa3529bfb3c733ffc
 https://conda.anaconda.org/conda-forge/noarch/readme_renderer-27.0-pyh9f0ad1d_0.tar.bz2#38446dff7f69efd3fab98ab4dc68c0c8
@@ -266,7 +266,7 @@ https://conda.anaconda.org/conda-forge/noarch/pytest-cov-2.10.1-pyh9f0ad1d_0.tar
 https://conda.anaconda.org/conda-forge/noarch/pytest-forked-1.2.0-pyh9f0ad1d_0.tar.bz2#d4bc635ac7fd58559a6f1a1f78354818
 https://conda.anaconda.org/conda-forge/noarch/requests-2.25.1-pyhd3deb0d_0.tar.bz2#ae687aba31a1c400192a86a2e993ffdc
 https://conda.anaconda.org/conda-forge/noarch/scikit-mdr-0.4.4-py_1.tar.bz2#9ce428157b9f31e2d1f4e48b93556159
-https://conda.anaconda.org/conda-forge/linux-64/selenium-3.141.0-py36h8c4c3a4_1002.tar.bz2#e63596de1519b98c94617c4ba8e3b327
+https://conda.anaconda.org/conda-forge/linux-64/selenium-3.141.0-py36h8f6f2f9_1002.tar.bz2#f747ac92d0e42c2d11b3655f2afe0436
 https://conda.anaconda.org/conda-forge/noarch/skrebate-0.61-pyh9f0ad1d_0.tar.bz2#a75047ba4c76ae7d75fb9b44f9b1a705
 https://conda.anaconda.org/conda-forge/noarch/yellowbrick-1.2-pyh9f0ad1d_0.tar.bz2#3eef320f403216b68eba3a6424f96b9c
 https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2#7c9c5295a0499bf56bbf084578618af5
@@ -295,7 +295,7 @@ https://conda.anaconda.org/conda-forge/noarch/nbclassic-0.2.6-pyhd8ed1ab_0.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/widgetsnbextension-3.5.1-py36h5fab9bb_4.tar.bz2#6919ca2c4ddec0166a900910d54ded67
 https://conda.anaconda.org/conda-forge/noarch/hvplot-0.7.0-pyhd3deb0d_0.tar.bz2#b2e8747e6b00559ed461c979766a2ed7
 https://conda.anaconda.org/conda-forge/noarch/ipywidgets-7.6.3-pyhd3deb0d_0.tar.bz2#536a9ed6d9e740f2b83d1a3c388e4388
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.4-pyhd8ed1ab_0.tar.bz2#f196ddf31157a9d42e724fde26790330
+https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.5-pyhd8ed1ab_0.tar.bz2#4824b73d683d4efb2f3dfb352b24544a
 https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.21-pyhd8ed1ab_0.tar.bz2#1f804e7d3cd16071e4c4e81567d529ce
 https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab_0.tar.bz2#912033f0b7f96ecb2bb73a24333541e2
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4

--- a/.github/locks/conda.test.linux-64-3.8-3.0.lock
+++ b/.github/locks/conda.test.linux-64-3.8-3.0.lock
@@ -1,5 +1,5 @@
 # platform: linux-64
-# env_hash: 2956ee28b73147ac801a44a75aed02f2c5fc8c18daaa0e799c5c9ff102845bd1
+# env_hash: 64e3c4a642bd0e0e0cd71ae38fb59c707c5e0fc1708ef404dbccf581b1d8642e
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
 https://conda.anaconda.org/conda-forge/linux-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#23b8f98a355030331f40d0245492f715
@@ -300,4 +300,3 @@ https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4
 https://conda.anaconda.org/conda-forge/noarch/ipylab-0.4.1-pyhd8ed1ab_0.tar.bz2#c48a8785da83bbddfc2e5e9173a656a1
 https://conda.anaconda.org/conda-forge/noarch/ipympl-0.6.2-pyhd8ed1ab_0.tar.bz2#fd94fe44ff7117af3bdc4b98098f8111
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-classic-0.1.2-pyhd8ed1ab_0.tar.bz2#1ba9135530eba24ef877abdeb5b00620

--- a/.github/locks/conda.test.linux-64-3.8-3.0.lock
+++ b/.github/locks/conda.test.linux-64-3.8-3.0.lock
@@ -1,5 +1,5 @@
 # platform: linux-64
-# env_hash: b7b1eabf8919f2af71d6628158f2e66bb7e46ad7fd16741b4e21ccef8f460ffa
+# env_hash: 2956ee28b73147ac801a44a75aed02f2c5fc8c18daaa0e799c5c9ff102845bd1
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2#d7c89558ba9fa0495403155b64376d81
 https://conda.anaconda.org/conda-forge/linux-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#23b8f98a355030331f40d0245492f715
@@ -250,7 +250,7 @@ https://conda.anaconda.org/conda-forge/noarch/xarray-0.16.2-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.2.3-py38h578d9bd_0.tar.bz2#53acd76e57c900918afe81910f471167
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/linux-64/keyring-21.8.0-py38h578d9bd_0.tar.bz2#0358a7702293487e431c89625d416c24
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
 https://conda.anaconda.org/conda-forge/linux-64/pylint-2.6.0-py38h32f6830_1.tar.bz2#1a653a6095a070fd5b908220e966e551
 https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-2.2.0-pyhd8ed1ab_0.tar.bz2#b4c969906732870a2e52208958730d6c
 https://conda.anaconda.org/conda-forge/noarch/readme_renderer-27.0-pyh9f0ad1d_0.tar.bz2#38446dff7f69efd3fab98ab4dc68c0c8

--- a/.github/locks/conda.test.linux-64-3.8-3.0.lock
+++ b/.github/locks/conda.test.linux-64-3.8-3.0.lock
@@ -62,7 +62,7 @@ https://conda.anaconda.org/conda-forge/linux-64/readline-8.0-he28a2e2_2.tar.bz2#
 https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.10-h21135ba_1.tar.bz2#c647f70aa7e3d4cc4e029cc1c9a99953
 https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.3-h58526e2_3.tar.bz2#6272fa8d98bd79c7978da0f7d2bb28da
 https://conda.anaconda.org/conda-forge/linux-64/zstd-1.4.8-ha95c52a_1.tar.bz2#ed4dbbaf7d81423678632bf982f45ede
-https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.4-h7ca028e_0.tar.bz2#1e6bf409916fdf455a5bb8627b626285
+https://conda.anaconda.org/conda-forge/linux-64/freetype-2.10.4-h0708190_1.tar.bz2#4a06f2ac2e5bfae7b6b245171c3f07aa
 https://conda.anaconda.org/conda-forge/linux-64/krb5-1.17.2-h926e7f8_0.tar.bz2#926325c11478d6e781e76072c117763b
 https://conda.anaconda.org/conda-forge/linux-64/libglib-2.66.4-h164308a_1.tar.bz2#d320eec766d1f41b94b75a09e020ed32
 https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.2.0-hdc55705_0.tar.bz2#f1406324f1d02fa26447a0a0f2dd0107
@@ -250,7 +250,7 @@ https://conda.anaconda.org/conda-forge/noarch/xarray-0.16.2-pyhd8ed1ab_0.tar.bz2
 https://conda.anaconda.org/conda-forge/linux-64/bokeh-2.2.3-py38h578d9bd_0.tar.bz2#53acd76e57c900918afe81910f471167
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/linux-64/keyring-21.8.0-py38h578d9bd_0.tar.bz2#0358a7702293487e431c89625d416c24
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
 https://conda.anaconda.org/conda-forge/linux-64/pylint-2.6.0-py38h32f6830_1.tar.bz2#1a653a6095a070fd5b908220e966e551
 https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-2.2.0-pyhd8ed1ab_0.tar.bz2#b4c969906732870a2e52208958730d6c
 https://conda.anaconda.org/conda-forge/noarch/readme_renderer-27.0-pyh9f0ad1d_0.tar.bz2#38446dff7f69efd3fab98ab4dc68c0c8
@@ -264,7 +264,7 @@ https://conda.anaconda.org/conda-forge/linux-64/py-xgboost-1.3.0-py38h578d9bd_1.
 https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.1-pyhd3deb0d_0.tar.bz2#f727bc4b55f5a7b48cec33be3a21b3ab
 https://conda.anaconda.org/conda-forge/noarch/requests-2.25.1-pyhd3deb0d_0.tar.bz2#ae687aba31a1c400192a86a2e993ffdc
 https://conda.anaconda.org/conda-forge/noarch/scikit-mdr-0.4.4-py_1.tar.bz2#9ce428157b9f31e2d1f4e48b93556159
-https://conda.anaconda.org/conda-forge/linux-64/selenium-3.141.0-py38h1e0a361_1002.tar.bz2#c5407c16d93e0e81d7113caf15d079b7
+https://conda.anaconda.org/conda-forge/linux-64/selenium-3.141.0-py38h497a2fe_1002.tar.bz2#5f732f64b2873cfc34a825c38faaeca0
 https://conda.anaconda.org/conda-forge/noarch/skrebate-0.61-pyh9f0ad1d_0.tar.bz2#a75047ba4c76ae7d75fb9b44f9b1a705
 https://conda.anaconda.org/conda-forge/noarch/yellowbrick-1.2-pyh9f0ad1d_0.tar.bz2#3eef320f403216b68eba3a6424f96b9c
 https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2#7c9c5295a0499bf56bbf084578618af5
@@ -294,7 +294,7 @@ https://conda.anaconda.org/conda-forge/noarch/nbclassic-0.2.6-pyhd8ed1ab_0.tar.b
 https://conda.anaconda.org/conda-forge/linux-64/widgetsnbextension-3.5.1-py38h578d9bd_4.tar.bz2#beb8a105545382ba138c81c926289b5b
 https://conda.anaconda.org/conda-forge/noarch/hvplot-0.7.0-pyhd3deb0d_0.tar.bz2#b2e8747e6b00559ed461c979766a2ed7
 https://conda.anaconda.org/conda-forge/noarch/ipywidgets-7.6.3-pyhd3deb0d_0.tar.bz2#536a9ed6d9e740f2b83d1a3c388e4388
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.4-pyhd8ed1ab_0.tar.bz2#f196ddf31157a9d42e724fde26790330
+https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.5-pyhd8ed1ab_0.tar.bz2#4824b73d683d4efb2f3dfb352b24544a
 https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.21-pyhd8ed1ab_0.tar.bz2#1f804e7d3cd16071e4c4e81567d529ce
 https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab_0.tar.bz2#912033f0b7f96ecb2bb73a24333541e2
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4

--- a/.github/locks/conda.test.osx-64-3.6-3.0.lock
+++ b/.github/locks/conda.test.osx-64-3.6-3.0.lock
@@ -1,5 +1,5 @@
 # platform: osx-64
-# env_hash: e257bcc89c39cd08735958674f5fe4bf2507a5461e6203368c05d26e3bd663e4
+# env_hash: c968722ed748942bce116b70d07c047819d0fd791aefb27a8537a8216dd6e37c
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/osx-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#96dd44c2471a638fb9cdc40aa2573d1b
 https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hc929b4f_4.tar.bz2#521b82c700a64bac7d8da27539422e91
@@ -293,4 +293,3 @@ https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4
 https://conda.anaconda.org/conda-forge/noarch/ipylab-0.4.1-pyhd8ed1ab_0.tar.bz2#c48a8785da83bbddfc2e5e9173a656a1
 https://conda.anaconda.org/conda-forge/noarch/ipympl-0.6.2-pyhd8ed1ab_0.tar.bz2#fd94fe44ff7117af3bdc4b98098f8111
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-classic-0.1.2-pyhd8ed1ab_0.tar.bz2#1ba9135530eba24ef877abdeb5b00620

--- a/.github/locks/conda.test.osx-64-3.6-3.0.lock
+++ b/.github/locks/conda.test.osx-64-3.6-3.0.lock
@@ -1,5 +1,5 @@
 # platform: osx-64
-# env_hash: dc548997a9e98fdad8c2f02c9005ca99ece307c13adde0857eb2098302faef48
+# env_hash: e257bcc89c39cd08735958674f5fe4bf2507a5461e6203368c05d26e3bd663e4
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/osx-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#96dd44c2471a638fb9cdc40aa2573d1b
 https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hc929b4f_4.tar.bz2#521b82c700a64bac7d8da27539422e91
@@ -240,7 +240,7 @@ https://conda.anaconda.org/conda-forge/osx-64/anyio-2.0.2-py36h79c6626_4.tar.bz2
 https://conda.anaconda.org/conda-forge/osx-64/bokeh-2.2.3-py36h79c6626_0.tar.bz2#63bd0ca18c943d98c29d0f948c8f569a
 https://conda.anaconda.org/conda-forge/noarch/importnb-0.7.0-pyhd8ed1ab_0.tar.bz2#73d3885a2fc883f4d19bc7b70baa37d2
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
 https://conda.anaconda.org/conda-forge/osx-64/pylint-2.6.0-py36h9f0ad1d_1.tar.bz2#7015ab091ac7f216fb1168ce76a6e1e3
 https://conda.anaconda.org/conda-forge/osx-64/pytest-6.2.1-py36h79c6626_1.tar.bz2#84d1b1e84947d710053abedeb48cc85f
 https://conda.anaconda.org/conda-forge/noarch/readme_renderer-27.0-pyh9f0ad1d_0.tar.bz2#38446dff7f69efd3fab98ab4dc68c0c8

--- a/.github/locks/conda.test.osx-64-3.6-3.0.lock
+++ b/.github/locks/conda.test.osx-64-3.6-3.0.lock
@@ -48,7 +48,7 @@ https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.10-h0419947_1.tar.bz2#9a79a
 https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.3-h74dc148_3.tar.bz2#365c52e91cb00d96d15bef9eddf9f7f8
 https://conda.anaconda.org/conda-forge/osx-64/zfp-0.5.5-h046ec9c_4.tar.bz2#c922f80fe4695b780d87ef69c12b002c
 https://conda.anaconda.org/conda-forge/osx-64/brunsli-0.1-h046ec9c_0.tar.bz2#28d47920c95b85499c9a61994cc49b87
-https://conda.anaconda.org/conda-forge/osx-64/freetype-2.10.4-h3f75d11_0.tar.bz2#84d0ef8511d5754eab4e6af79fb5d5b3
+https://conda.anaconda.org/conda-forge/osx-64/freetype-2.10.4-h4cff582_1.tar.bz2#5a136a432c6062362cd7990c514bd8d6
 https://conda.anaconda.org/conda-forge/osx-64/gettext-0.19.8.1-h7937167_1005.tar.bz2#52fd84c5cc5d61a6e05885f44d033efa
 https://conda.anaconda.org/conda-forge/osx-64/krb5-1.17.2-h60d9502_0.tar.bz2#abf2add2a1ade1920b25a8f3327a1aa0
 https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-7_mkl.tar.bz2#fbc6e62f458182d79035f965e9cc85fe
@@ -240,7 +240,7 @@ https://conda.anaconda.org/conda-forge/osx-64/anyio-2.0.2-py36h79c6626_4.tar.bz2
 https://conda.anaconda.org/conda-forge/osx-64/bokeh-2.2.3-py36h79c6626_0.tar.bz2#63bd0ca18c943d98c29d0f948c8f569a
 https://conda.anaconda.org/conda-forge/noarch/importnb-0.7.0-pyhd8ed1ab_0.tar.bz2#73d3885a2fc883f4d19bc7b70baa37d2
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
 https://conda.anaconda.org/conda-forge/osx-64/pylint-2.6.0-py36h9f0ad1d_1.tar.bz2#7015ab091ac7f216fb1168ce76a6e1e3
 https://conda.anaconda.org/conda-forge/osx-64/pytest-6.2.1-py36h79c6626_1.tar.bz2#84d1b1e84947d710053abedeb48cc85f
 https://conda.anaconda.org/conda-forge/noarch/readme_renderer-27.0-pyh9f0ad1d_0.tar.bz2#38446dff7f69efd3fab98ab4dc68c0c8
@@ -258,7 +258,7 @@ https://conda.anaconda.org/conda-forge/noarch/pytest-cov-2.10.1-pyh9f0ad1d_0.tar
 https://conda.anaconda.org/conda-forge/noarch/pytest-forked-1.2.0-pyh9f0ad1d_0.tar.bz2#d4bc635ac7fd58559a6f1a1f78354818
 https://conda.anaconda.org/conda-forge/noarch/requests-2.25.1-pyhd3deb0d_0.tar.bz2#ae687aba31a1c400192a86a2e993ffdc
 https://conda.anaconda.org/conda-forge/noarch/scikit-mdr-0.4.4-py_1.tar.bz2#9ce428157b9f31e2d1f4e48b93556159
-https://conda.anaconda.org/conda-forge/osx-64/selenium-3.141.0-py36h9de38fb_1002.tar.bz2#3f34632ea9d9dc52fbf35b43f81fe615
+https://conda.anaconda.org/conda-forge/osx-64/selenium-3.141.0-py36h20b66c6_1002.tar.bz2#903154f4cde0ce4c549dff8e2cfcd6fd
 https://conda.anaconda.org/conda-forge/noarch/skrebate-0.61-pyh9f0ad1d_0.tar.bz2#a75047ba4c76ae7d75fb9b44f9b1a705
 https://conda.anaconda.org/conda-forge/noarch/yellowbrick-1.2-pyh9f0ad1d_0.tar.bz2#3eef320f403216b68eba3a6424f96b9c
 https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2#7c9c5295a0499bf56bbf084578618af5
@@ -287,7 +287,7 @@ https://conda.anaconda.org/conda-forge/noarch/nbclassic-0.2.6-pyhd8ed1ab_0.tar.b
 https://conda.anaconda.org/conda-forge/osx-64/widgetsnbextension-3.5.1-py36h79c6626_4.tar.bz2#4fd4c9e381f16caf01d9a5244eeea563
 https://conda.anaconda.org/conda-forge/noarch/hvplot-0.7.0-pyhd3deb0d_0.tar.bz2#b2e8747e6b00559ed461c979766a2ed7
 https://conda.anaconda.org/conda-forge/noarch/ipywidgets-7.6.3-pyhd3deb0d_0.tar.bz2#536a9ed6d9e740f2b83d1a3c388e4388
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.4-pyhd8ed1ab_0.tar.bz2#f196ddf31157a9d42e724fde26790330
+https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.5-pyhd8ed1ab_0.tar.bz2#4824b73d683d4efb2f3dfb352b24544a
 https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.21-pyhd8ed1ab_0.tar.bz2#1f804e7d3cd16071e4c4e81567d529ce
 https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab_0.tar.bz2#912033f0b7f96ecb2bb73a24333541e2
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4

--- a/.github/locks/conda.test.osx-64-3.8-3.0.lock
+++ b/.github/locks/conda.test.osx-64-3.8-3.0.lock
@@ -49,7 +49,7 @@ https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.10-h0419947_1.tar.bz2#9a79a
 https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.3-h74dc148_3.tar.bz2#365c52e91cb00d96d15bef9eddf9f7f8
 https://conda.anaconda.org/conda-forge/osx-64/zfp-0.5.5-h046ec9c_4.tar.bz2#c922f80fe4695b780d87ef69c12b002c
 https://conda.anaconda.org/conda-forge/osx-64/brunsli-0.1-h046ec9c_0.tar.bz2#28d47920c95b85499c9a61994cc49b87
-https://conda.anaconda.org/conda-forge/osx-64/freetype-2.10.4-h3f75d11_0.tar.bz2#84d0ef8511d5754eab4e6af79fb5d5b3
+https://conda.anaconda.org/conda-forge/osx-64/freetype-2.10.4-h4cff582_1.tar.bz2#5a136a432c6062362cd7990c514bd8d6
 https://conda.anaconda.org/conda-forge/osx-64/gettext-0.19.8.1-h7937167_1005.tar.bz2#52fd84c5cc5d61a6e05885f44d033efa
 https://conda.anaconda.org/conda-forge/osx-64/krb5-1.17.2-h60d9502_0.tar.bz2#abf2add2a1ade1920b25a8f3327a1aa0
 https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-7_mkl.tar.bz2#fbc6e62f458182d79035f965e9cc85fe
@@ -242,7 +242,7 @@ https://conda.anaconda.org/conda-forge/noarch/tifffile-2021.1.11-pyhd8ed1ab_0.ta
 https://conda.anaconda.org/conda-forge/noarch/xarray-0.16.2-pyhd8ed1ab_0.tar.bz2#45057a982fbac8e5c5ba5167358d4bbb
 https://conda.anaconda.org/conda-forge/osx-64/bokeh-2.2.3-py38h50d1736_0.tar.bz2#971d4bcce962d2196fcc638ae7d8d165
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
 https://conda.anaconda.org/conda-forge/osx-64/pylint-2.6.0-py38h32f6830_1.tar.bz2#98f8c6d424d85e2c339b72c1835c3bba
 https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-2.2.0-pyhd8ed1ab_0.tar.bz2#b4c969906732870a2e52208958730d6c
 https://conda.anaconda.org/conda-forge/noarch/readme_renderer-27.0-pyh9f0ad1d_0.tar.bz2#38446dff7f69efd3fab98ab4dc68c0c8
@@ -256,7 +256,7 @@ https://conda.anaconda.org/conda-forge/osx-64/py-xgboost-1.3.0-py38h50d1736_1.ta
 https://conda.anaconda.org/conda-forge/noarch/pynndescent-0.5.1-pyhd3deb0d_0.tar.bz2#f727bc4b55f5a7b48cec33be3a21b3ab
 https://conda.anaconda.org/conda-forge/noarch/requests-2.25.1-pyhd3deb0d_0.tar.bz2#ae687aba31a1c400192a86a2e993ffdc
 https://conda.anaconda.org/conda-forge/noarch/scikit-mdr-0.4.4-py_1.tar.bz2#9ce428157b9f31e2d1f4e48b93556159
-https://conda.anaconda.org/conda-forge/osx-64/selenium-3.141.0-py38h4d0b108_1002.tar.bz2#22c4963b1ca8d159fccd7630eb98b0e9
+https://conda.anaconda.org/conda-forge/osx-64/selenium-3.141.0-py38h5406a74_1002.tar.bz2#4da1bd4d90f6474760e3c99660dfd38c
 https://conda.anaconda.org/conda-forge/noarch/skrebate-0.61-pyh9f0ad1d_0.tar.bz2#a75047ba4c76ae7d75fb9b44f9b1a705
 https://conda.anaconda.org/conda-forge/noarch/yellowbrick-1.2-pyh9f0ad1d_0.tar.bz2#3eef320f403216b68eba3a6424f96b9c
 https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2#7c9c5295a0499bf56bbf084578618af5
@@ -286,7 +286,7 @@ https://conda.anaconda.org/conda-forge/noarch/nbclassic-0.2.6-pyhd8ed1ab_0.tar.b
 https://conda.anaconda.org/conda-forge/osx-64/widgetsnbextension-3.5.1-py38h50d1736_4.tar.bz2#7d69dd67c8a01d72b41e73102141afb8
 https://conda.anaconda.org/conda-forge/noarch/hvplot-0.7.0-pyhd3deb0d_0.tar.bz2#b2e8747e6b00559ed461c979766a2ed7
 https://conda.anaconda.org/conda-forge/noarch/ipywidgets-7.6.3-pyhd3deb0d_0.tar.bz2#536a9ed6d9e740f2b83d1a3c388e4388
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.4-pyhd8ed1ab_0.tar.bz2#f196ddf31157a9d42e724fde26790330
+https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.5-pyhd8ed1ab_0.tar.bz2#4824b73d683d4efb2f3dfb352b24544a
 https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.21-pyhd8ed1ab_0.tar.bz2#1f804e7d3cd16071e4c4e81567d529ce
 https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab_0.tar.bz2#912033f0b7f96ecb2bb73a24333541e2
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4

--- a/.github/locks/conda.test.osx-64-3.8-3.0.lock
+++ b/.github/locks/conda.test.osx-64-3.8-3.0.lock
@@ -1,5 +1,5 @@
 # platform: osx-64
-# env_hash: d60a334338cec202638bd95e1bd55fa621f7fe6366f1057759519c5d071b18ec
+# env_hash: f6efad306f8561cf8d86fedb427f56a7c708ad22025663b0c5edf0f8163916b2
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/osx-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#96dd44c2471a638fb9cdc40aa2573d1b
 https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hc929b4f_4.tar.bz2#521b82c700a64bac7d8da27539422e91
@@ -242,7 +242,7 @@ https://conda.anaconda.org/conda-forge/noarch/tifffile-2021.1.11-pyhd8ed1ab_0.ta
 https://conda.anaconda.org/conda-forge/noarch/xarray-0.16.2-pyhd8ed1ab_0.tar.bz2#45057a982fbac8e5c5ba5167358d4bbb
 https://conda.anaconda.org/conda-forge/osx-64/bokeh-2.2.3-py38h50d1736_0.tar.bz2#971d4bcce962d2196fcc638ae7d8d165
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
 https://conda.anaconda.org/conda-forge/osx-64/pylint-2.6.0-py38h32f6830_1.tar.bz2#98f8c6d424d85e2c339b72c1835c3bba
 https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-2.2.0-pyhd8ed1ab_0.tar.bz2#b4c969906732870a2e52208958730d6c
 https://conda.anaconda.org/conda-forge/noarch/readme_renderer-27.0-pyh9f0ad1d_0.tar.bz2#38446dff7f69efd3fab98ab4dc68c0c8

--- a/.github/locks/conda.test.osx-64-3.8-3.0.lock
+++ b/.github/locks/conda.test.osx-64-3.8-3.0.lock
@@ -1,5 +1,5 @@
 # platform: osx-64
-# env_hash: f6efad306f8561cf8d86fedb427f56a7c708ad22025663b0c5edf0f8163916b2
+# env_hash: d6f069d0f71e09f2f59dfd9d0aee95362321b7b26d7d5c0e1f3a2cf1bfdcf1ad
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/osx-64/_py-xgboost-mutex-2.0-cpu_0.tar.bz2#96dd44c2471a638fb9cdc40aa2573d1b
 https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hc929b4f_4.tar.bz2#521b82c700a64bac7d8da27539422e91
@@ -292,4 +292,3 @@ https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4
 https://conda.anaconda.org/conda-forge/noarch/ipylab-0.4.1-pyhd8ed1ab_0.tar.bz2#c48a8785da83bbddfc2e5e9173a656a1
 https://conda.anaconda.org/conda-forge/noarch/ipympl-0.6.2-pyhd8ed1ab_0.tar.bz2#fd94fe44ff7117af3bdc4b98098f8111
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-classic-0.1.2-pyhd8ed1ab_0.tar.bz2#1ba9135530eba24ef877abdeb5b00620

--- a/.github/locks/conda.test.win-64-3.6-3.0.lock
+++ b/.github/locks/conda.test.win-64-3.6-3.0.lock
@@ -1,5 +1,5 @@
 # platform: win-64
-# env_hash: b7612aaab8e19cbbdd93dfbea08cb26d1376fb09bfc7effe9a25ed31c2ed3d05
+# env_hash: f4ceb253d6afd39b11733b5152f2e9d45431d66de07cf0eff315742201ddec92
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/win-64/git-2.30.0-h57928b3_0.tar.bz2#42cafe38cf1038cba7465b9a816f9883
 https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2#9a66894dfd07c4510beb6b3f9672ccc0
@@ -274,4 +274,3 @@ https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4
 https://conda.anaconda.org/conda-forge/noarch/ipylab-0.4.1-pyhd8ed1ab_0.tar.bz2#c48a8785da83bbddfc2e5e9173a656a1
 https://conda.anaconda.org/conda-forge/noarch/ipympl-0.6.2-pyhd8ed1ab_0.tar.bz2#fd94fe44ff7117af3bdc4b98098f8111
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-classic-0.1.2-pyhd8ed1ab_0.tar.bz2#1ba9135530eba24ef877abdeb5b00620

--- a/.github/locks/conda.test.win-64-3.6-3.0.lock
+++ b/.github/locks/conda.test.win-64-3.6-3.0.lock
@@ -1,5 +1,5 @@
 # platform: win-64
-# env_hash: fa0ce7fe1cb3e30666254ed62bdf9ed7528056abca82c4f726f3ffdd6222df6b
+# env_hash: b7612aaab8e19cbbdd93dfbea08cb26d1376fb09bfc7effe9a25ed31c2ed3d05
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/win-64/git-2.30.0-h57928b3_0.tar.bz2#42cafe38cf1038cba7465b9a816f9883
 https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2#9a66894dfd07c4510beb6b3f9672ccc0
@@ -209,7 +209,7 @@ https://conda.anaconda.org/conda-forge/win-64/terminado-0.9.2-py36ha15d459_0.tar
 https://conda.anaconda.org/conda-forge/win-64/anyio-2.0.2-py36ha15d459_4.tar.bz2#ba5fd58f24a12a4e132dd7849ad780ce
 https://conda.anaconda.org/conda-forge/noarch/importnb-0.7.0-pyhd8ed1ab_0.tar.bz2#73d3885a2fc883f4d19bc7b70baa37d2
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
 https://conda.anaconda.org/conda-forge/win-64/numpy-1.19.5-py36hd1b969e_1.tar.bz2#66491a2bd33efe489b734573273b06d7
 https://conda.anaconda.org/conda-forge/win-64/pylint-2.6.0-py36h9f0ad1d_1.tar.bz2#809fe69812f9c9c173d85f95f85770f1
 https://conda.anaconda.org/conda-forge/win-64/pytest-6.2.1-py36ha15d459_1.tar.bz2#96140a7fee6bcc041820ce5d504baa11

--- a/.github/locks/conda.test.win-64-3.6-3.0.lock
+++ b/.github/locks/conda.test.win-64-3.6-3.0.lock
@@ -120,7 +120,7 @@ https://conda.anaconda.org/conda-forge/win-64/cytoolz-0.11.0-py36h68aa20f_2.tar.
 https://conda.anaconda.org/conda-forge/win-64/docutils-0.16-py36ha15d459_3.tar.bz2#288069fe6f712d0b900082d2381f8953
 https://conda.anaconda.org/conda-forge/win-64/doit-0.33.1-py36h9f0ad1d_1.tar.bz2#eda38f9e8dc256068db9f41d2c26febb
 https://conda.anaconda.org/conda-forge/noarch/execnet-1.7.1-py_0.tar.bz2#b68d9d4464296840b68761d21487172a
-https://conda.anaconda.org/conda-forge/win-64/freetype-2.10.4-h546665d_0.tar.bz2#ff064b199df93841b871a5c1f600e47c
+https://conda.anaconda.org/conda-forge/win-64/freetype-2.10.4-h546665d_1.tar.bz2#1215a2e49d23da91c28d97cff8de35ea
 https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.5-py_0.tar.bz2#94c135f9db6e89c6a848d3f7ae2cc66b
 https://conda.anaconda.org/conda-forge/win-64/idna_ssl-1.1.0-py36h9f0ad1d_1001.tar.bz2#ee34dbdae45e6bc51f7c695cae87010d
 https://conda.anaconda.org/conda-forge/win-64/immutables-0.14-py36h68aa20f_1.tar.bz2#72bb2c9ef819af4a0ee997a2ae042f3d
@@ -209,7 +209,7 @@ https://conda.anaconda.org/conda-forge/win-64/terminado-0.9.2-py36ha15d459_0.tar
 https://conda.anaconda.org/conda-forge/win-64/anyio-2.0.2-py36ha15d459_4.tar.bz2#ba5fd58f24a12a4e132dd7849ad780ce
 https://conda.anaconda.org/conda-forge/noarch/importnb-0.7.0-pyhd8ed1ab_0.tar.bz2#73d3885a2fc883f4d19bc7b70baa37d2
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
 https://conda.anaconda.org/conda-forge/win-64/numpy-1.19.5-py36hd1b969e_1.tar.bz2#66491a2bd33efe489b734573273b06d7
 https://conda.anaconda.org/conda-forge/win-64/pylint-2.6.0-py36h9f0ad1d_1.tar.bz2#809fe69812f9c9c173d85f95f85770f1
 https://conda.anaconda.org/conda-forge/win-64/pytest-6.2.1-py36ha15d459_1.tar.bz2#96140a7fee6bcc041820ce5d504baa11
@@ -232,7 +232,7 @@ https://conda.anaconda.org/conda-forge/noarch/pytest-forked-1.2.0-pyh9f0ad1d_0.t
 https://conda.anaconda.org/conda-forge/win-64/pywavelets-1.1.1-py36h6434af4_3.tar.bz2#3edfa4c3fc701a92ed8fe69b974effa3
 https://conda.anaconda.org/conda-forge/noarch/requests-2.25.1-pyhd3deb0d_0.tar.bz2#ae687aba31a1c400192a86a2e993ffdc
 https://conda.anaconda.org/conda-forge/win-64/scipy-1.5.3-py36h7ff6e69_0.tar.bz2#d9c77e36849c5c23e713c72e8a39dd39
-https://conda.anaconda.org/conda-forge/win-64/selenium-3.141.0-py36h779f372_1002.tar.bz2#02c7da0e1942c1b7d4af4919ed1d0f16
+https://conda.anaconda.org/conda-forge/win-64/selenium-3.141.0-py36h68aa20f_1002.tar.bz2#d0268dcfdfd4bb393fb8360fd8e78335
 https://conda.anaconda.org/conda-forge/noarch/dask-2020.12.0-pyhd8ed1ab_0.tar.bz2#b10d9c6984a9aebdbd26a311b3faf906
 https://conda.anaconda.org/conda-forge/win-64/ipython-7.16.1-py36h7b2dad6_2.tar.bz2#e69ba043a57a9b40eadf45ced5b581f5
 https://conda.anaconda.org/conda-forge/win-64/nbconvert-6.0.7-py36ha15d459_3.tar.bz2#307a9bfc241eee6f939c0ba028af4154
@@ -268,7 +268,7 @@ https://conda.anaconda.org/conda-forge/noarch/nbclassic-0.2.6-pyhd8ed1ab_0.tar.b
 https://conda.anaconda.org/conda-forge/win-64/widgetsnbextension-3.5.1-py36ha15d459_4.tar.bz2#2c71f6a23d569494cf7e07b261868e31
 https://conda.anaconda.org/conda-forge/noarch/hvplot-0.7.0-pyhd3deb0d_0.tar.bz2#b2e8747e6b00559ed461c979766a2ed7
 https://conda.anaconda.org/conda-forge/noarch/ipywidgets-7.6.3-pyhd3deb0d_0.tar.bz2#536a9ed6d9e740f2b83d1a3c388e4388
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.4-pyhd8ed1ab_0.tar.bz2#f196ddf31157a9d42e724fde26790330
+https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.5-pyhd8ed1ab_0.tar.bz2#4824b73d683d4efb2f3dfb352b24544a
 https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.21-pyhd8ed1ab_0.tar.bz2#1f804e7d3cd16071e4c4e81567d529ce
 https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab_0.tar.bz2#912033f0b7f96ecb2bb73a24333541e2
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4

--- a/.github/locks/conda.test.win-64-3.8-3.0.lock
+++ b/.github/locks/conda.test.win-64-3.8-3.0.lock
@@ -1,5 +1,5 @@
 # platform: win-64
-# env_hash: 9a93d68d295b5b510bd50cc3d978ad0f1b8c24a55fec4a9e0779a0608853f7cf
+# env_hash: 29d5656dcce6d10dd8527f43586d4c1c018beae2d614d0e486598590fbf52526
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/win-64/git-2.30.0-h57928b3_0.tar.bz2#42cafe38cf1038cba7465b9a816f9883
 https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2#9a66894dfd07c4510beb6b3f9672ccc0
@@ -219,7 +219,7 @@ https://conda.anaconda.org/conda-forge/win-64/imagecodecs-2021.1.11-py38h1ceb79b
 https://conda.anaconda.org/conda-forge/noarch/imageio-2.9.0-py_0.tar.bz2#62ad9e579278e777d4abaa8c9312b6a7
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.3.3-py38h34ddff4_0.tar.bz2#8d2180013c805f7f841484b7d0ac385e
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
 https://conda.anaconda.org/conda-forge/win-64/numba-0.52.0-py38h4c96930_0.tar.bz2#4a48c9f98fdbac8848494229d194a4bc
 https://conda.anaconda.org/conda-forge/win-64/pandas-1.2.0-py38h4c96930_1.tar.bz2#55ffd9d0cc43b397a0b3d2e033c1e112
 https://conda.anaconda.org/conda-forge/win-64/pylint-2.6.0-py38h32f6830_1.tar.bz2#56b889e135b61ee716d2397f53f6abc5

--- a/.github/locks/conda.test.win-64-3.8-3.0.lock
+++ b/.github/locks/conda.test.win-64-3.8-3.0.lock
@@ -1,5 +1,5 @@
 # platform: win-64
-# env_hash: 29d5656dcce6d10dd8527f43586d4c1c018beae2d614d0e486598590fbf52526
+# env_hash: 2bbf251914450eaa38813f83491f52713e041d40dbbcf950f686e339edeba0f9
 @EXPLICIT
 https://conda.anaconda.org/conda-forge/win-64/git-2.30.0-h57928b3_0.tar.bz2#42cafe38cf1038cba7465b9a816f9883
 https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2#9a66894dfd07c4510beb6b3f9672ccc0
@@ -274,4 +274,3 @@ https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4
 https://conda.anaconda.org/conda-forge/noarch/ipylab-0.4.1-pyhd8ed1ab_0.tar.bz2#c48a8785da83bbddfc2e5e9173a656a1
 https://conda.anaconda.org/conda-forge/noarch/ipympl-0.6.2-pyhd8ed1ab_0.tar.bz2#fd94fe44ff7117af3bdc4b98098f8111
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-classic-0.1.2-pyhd8ed1ab_0.tar.bz2#1ba9135530eba24ef877abdeb5b00620

--- a/.github/locks/conda.test.win-64-3.8-3.0.lock
+++ b/.github/locks/conda.test.win-64-3.8-3.0.lock
@@ -61,7 +61,7 @@ https://conda.anaconda.org/conda-forge/noarch/dataclasses-0.7-pyhb2cacf7_7.tar.b
 https://conda.anaconda.org/conda-forge/noarch/decorator-4.4.2-py_0.tar.bz2#d2eabb9cabd212e1ec6a9463bd846243
 https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.6.0-py_0.tar.bz2#37e1033daee0e2edaa5ff42584c52b21
 https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.3-pyhd8ed1ab_1003.tar.bz2#bbf9a201f6ce99a506f4955374d9a9f4
-https://conda.anaconda.org/conda-forge/win-64/freetype-2.10.4-h546665d_0.tar.bz2#ff064b199df93841b871a5c1f600e47c
+https://conda.anaconda.org/conda-forge/win-64/freetype-2.10.4-h546665d_1.tar.bz2#1215a2e49d23da91c28d97cff8de35ea
 https://conda.anaconda.org/conda-forge/noarch/frozendict-1.2-pyh9f0ad1d_3.tar.bz2#6916a506e34f8f17382f5abf3e6368bb
 https://conda.anaconda.org/conda-forge/noarch/fsspec-0.8.5-pyhd8ed1ab_0.tar.bz2#6f86dae0901b373f96b7e92768ef6ebe
 https://conda.anaconda.org/conda-forge/noarch/heapdict-1.0.1-py_0.tar.bz2#77242bfb1e74a627fb06319b5a2d3b95
@@ -219,7 +219,7 @@ https://conda.anaconda.org/conda-forge/win-64/imagecodecs-2021.1.11-py38h1ceb79b
 https://conda.anaconda.org/conda-forge/noarch/imageio-2.9.0-py_0.tar.bz2#62ad9e579278e777d4abaa8c9312b6a7
 https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.1.2-pyh9f0ad1d_0.tar.bz2#2cbd910890bb328e8959246a1e16fac7
 https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.3.3-py38h34ddff4_0.tar.bz2#8d2180013c805f7f841484b7d0ac385e
-https://conda.anaconda.org/conda-forge/noarch/nbformat-5.0.8-py_0.tar.bz2#12aaf0d8795a5c375757b49a08e011a2
+https://conda.anaconda.org/conda-forge/noarch/nbformat-5.1.0-pyhd8ed1ab_0.tar.bz2#4ed0a33e44d7e14a22f71113f09511f1
 https://conda.anaconda.org/conda-forge/win-64/numba-0.52.0-py38h4c96930_0.tar.bz2#4a48c9f98fdbac8848494229d194a4bc
 https://conda.anaconda.org/conda-forge/win-64/pandas-1.2.0-py38h4c96930_1.tar.bz2#55ffd9d0cc43b397a0b3d2e033c1e112
 https://conda.anaconda.org/conda-forge/win-64/pylint-2.6.0-py38h32f6830_1.tar.bz2#56b889e135b61ee716d2397f53f6abc5
@@ -234,7 +234,7 @@ https://conda.anaconda.org/conda-forge/noarch/nbclient-0.5.1-py_0.tar.bz2#4efba3
 https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.10-pyha770c72_0.tar.bz2#8f2f65a9eedc7b3a9c5ea6374c541453
 https://conda.anaconda.org/conda-forge/noarch/requests-2.25.1-pyhd3deb0d_0.tar.bz2#ae687aba31a1c400192a86a2e993ffdc
 https://conda.anaconda.org/conda-forge/win-64/scikit-learn-0.24.0-py38ha09990b_0.tar.bz2#1bd5e60f69ee458519ec2277ea089158
-https://conda.anaconda.org/conda-forge/win-64/selenium-3.141.0-py38h1e8a9f7_1002.tar.bz2#82eb5bcde73994ab844862ce24127e70
+https://conda.anaconda.org/conda-forge/win-64/selenium-3.141.0-py38h294d835_1002.tar.bz2#826ee023ea7bade5a55c730a0b82466c
 https://conda.anaconda.org/conda-forge/noarch/tifffile-2021.1.11-pyhd8ed1ab_0.tar.bz2#26b4bbfa5456030a7578128bac511dae
 https://conda.anaconda.org/conda-forge/noarch/xarray-0.16.2-pyhd8ed1ab_0.tar.bz2#45057a982fbac8e5c5ba5167358d4bbb
 https://conda.anaconda.org/conda-forge/noarch/dask-glm-0.2.0-py_1.tar.bz2#7c9c5295a0499bf56bbf084578618af5
@@ -268,7 +268,7 @@ https://conda.anaconda.org/conda-forge/noarch/nbclassic-0.2.6-pyhd8ed1ab_0.tar.b
 https://conda.anaconda.org/conda-forge/win-64/widgetsnbextension-3.5.1-py38haa244fe_4.tar.bz2#36985a09e5fcd85459c2ab647020c603
 https://conda.anaconda.org/conda-forge/noarch/hvplot-0.7.0-pyhd3deb0d_0.tar.bz2#b2e8747e6b00559ed461c979766a2ed7
 https://conda.anaconda.org/conda-forge/noarch/ipywidgets-7.6.3-pyhd3deb0d_0.tar.bz2#536a9ed6d9e740f2b83d1a3c388e4388
-https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.4-pyhd8ed1ab_0.tar.bz2#f196ddf31157a9d42e724fde26790330
+https://conda.anaconda.org/conda-forge/noarch/jupyterlab-3.0.5-pyhd8ed1ab_0.tar.bz2#4824b73d683d4efb2f3dfb352b24544a
 https://conda.anaconda.org/conda-forge/noarch/bqplot-0.12.21-pyhd8ed1ab_0.tar.bz2#1f804e7d3cd16071e4c4e81567d529ce
 https://conda.anaconda.org/conda-forge/noarch/dask-labextension-5.0.0-pyhd8ed1ab_0.tar.bz2#912033f0b7f96ecb2bb73a24333541e2
 https://conda.anaconda.org/conda-forge/noarch/ipycytoscape-1.2.0-pyhd8ed1ab_0.tar.bz2#2246dd9d1101ac92688e7d942fd86ed4

--- a/.github/reqs/base.yml
+++ b/.github/reqs/base.yml
@@ -13,5 +13,6 @@ dependencies:
   - pip
   - python
   - twine
-  # remove at some point
+  # TODO: remove at some point
   - jedi <0.18.0
+  - nbformat >=5,!=5.1.0,!=5.1.1

--- a/.github/reqs/tpot.yml
+++ b/.github/reqs/tpot.yml
@@ -25,4 +25,3 @@ dependencies:
   - hvplot
   - ipycytoscape
   - ipylab
-  - jupyterlab-classic

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,11 @@
 # Contributing to wxyz
 
-Get [Mambaforge][]. Create/activate a dev environment from a [lockfile][], list tasks.
+Get [Mambaforge][]. Start a dev environment from a [lockfile][], list tasks, launch Lab:
 
     mamba create --prefix envs/docs --file .github/locks/conda.docs.linux-64-3.8-3.0.lock
     source activate envs/docs
-    doit list --status
+    doit list --status --all
+    doit lab
 
 [mambaforge]: https://github.com/conda-forge/miniforge/releases
 [lockfile]: ./.github/locks
@@ -17,6 +18,10 @@ Local development and continuous integration are both driven by [pydoit](https:/
 
     doit list
 
+> `--all` and `--status` can be combined for a lot of quick information.
+
+    doit list --all --status | sort
+
 ### Run everything up to development
 
     doit
@@ -24,18 +29,35 @@ Local development and continuous integration are both driven by [pydoit](https:/
 > This actually runs the `binder` task, which is used in `postBuild` for the
 > interactive demo
 
+The equivalent of _starting_ Binder is:
+
+    doit lab
+
 ### Do everything to prepare for a release
 
     doit release
+
+### Do everything to prepare the docs site
+
+    doit release
+    doit docs
+
+> This is two un-coupled `doit` runs, so that it possible to replace notebook
+> widget data or screenshots "hot" without worry too much about where they came
+> from.
 
 ### Live Development
 
 To rebuild the labextension and your JupyterLab, use:
 
-    doit watch
+    doit watch:lab
 
 > When new files are created, it is usually necessary to re-start the watch command,
 > stop it with <kbd>Ctrl+C</kbd>.
+
+Semi-incompatibly, you can live run the docs build process (with some limitations)
+
+    doit watch:docs
 
 ## Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Each notebook should:
 ### Robot Framework Testing
 
 Where appropriate, individual components should be tested with Robot Framework
-tests. Ideal tests include thoroughly excercising the demo notebooks as a user would.
+tests. Ideal tests include thoroughly exercising the demo notebooks as a user would.
 
     doit robot
 

--- a/docs/developing.ipynb
+++ b/docs/developing.ipynb
@@ -4,20 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## WXYZ Documentation\n",
-    "```{toctree}\n",
-    ":maxdepth: 2\n",
-    "gallery\n",
-    "widgets\n",
-    "developing\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```{include} ../README.md\n",
+    "```{include} ../CONTRIBUTING.md\n",
     "\n",
     "```"
    ]

--- a/docs/dictionary.txt
+++ b/docs/dictionary.txt
@@ -39,6 +39,7 @@ dirs
 DockBox
 DockPanel
 DockPop
+doit
 dom
 domwidget
 DOMWidget
@@ -101,6 +102,7 @@ JupyterWatcher
 klass
 kwargs
 LabBase
+labextension
 laccept
 lactive
 ladd
@@ -244,6 +246,8 @@ lmultiple
 lname
 lnotify
 lobserve
+lockfile
+lockfiles
 LoggingHasTraits
 lon
 lopen
@@ -340,11 +344,13 @@ lworking
 lworkTime
 lzoom
 MacOS
+Mambaforge
 msg
 NoneType
 numpy
 png
 proto
+pydoit
 rankdir
 repr
 rgba
@@ -374,6 +380,7 @@ traitlets
 traitname
 TraitType
 TraitType
+un
 UnJSON
 UnYAML
 url

--- a/src/wxyz_datagrid/src/wxyz/datagrid/js/src/constants.ts
+++ b/src/wxyz_datagrid/src/wxyz/datagrid/js/src/constants.ts
@@ -1,0 +1,4 @@
+import __package__ from '../package.json';
+
+export const NAME = __package__.name;
+export const VERSION = __package__.version;

--- a/src/wxyz_datagrid/src/wxyz/datagrid/js/src/index.ts
+++ b/src/wxyz_datagrid/src/wxyz/datagrid/js/src/index.ts
@@ -1,4 +1,4 @@
-import __package__ from '../package.json';
-
-export const NAME = __package__.name;
-export const VERSION = __package__.version;
+export * from './constants';
+export * from './widgets';
+export * from './widgets/models/cells';
+export * from './widgets/pmodels/jsonmodel';

--- a/src/wxyz_datagrid/src/wxyz/datagrid/js/src/plugin.ts
+++ b/src/wxyz_datagrid/src/wxyz/datagrid/js/src/plugin.ts
@@ -3,7 +3,7 @@ import { Widget } from '@lumino/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import { NAME, VERSION } from '.';
+import { NAME, VERSION } from './constants';
 import '../style/index.css';
 
 const EXTENSION_ID = `${NAME}:plugin`;

--- a/src/wxyz_datagrid/src/wxyz/datagrid/js/src/widgets/stylegrid.ts
+++ b/src/wxyz_datagrid/src/wxyz/datagrid/js/src/widgets/stylegrid.ts
@@ -2,7 +2,7 @@ import { WXYZ } from '@deathbeds/wxyz-core';
 import { unpack_models as deserialize } from '@jupyter-widgets/base';
 import { DataGridModel, DataGridView } from './datagrid';
 import { StyleGrid } from './pwidgets/stylegrid';
-import { NAME, VERSION } from '..';
+import { NAME, VERSION } from '../constants';
 
 const CSS = {
   STYLE_GRID: 'jp-WXYZ-StyleGrid',

--- a/src/wxyz_dvcs/src/wxyz/dvcs/js/src/constants.ts
+++ b/src/wxyz_dvcs/src/wxyz/dvcs/js/src/constants.ts
@@ -1,0 +1,4 @@
+import __package__ from '../package.json';
+
+export const NAME = __package__.name;
+export const VERSION = __package__.version;

--- a/src/wxyz_dvcs/src/wxyz/dvcs/js/src/index.ts
+++ b/src/wxyz_dvcs/src/wxyz/dvcs/js/src/index.ts
@@ -1,4 +1,2 @@
-import __package__ from '../package.json';
-
-export const NAME = __package__.name;
-export const VERSION = __package__.version;
+export * from './constants';
+export * from './widgets';

--- a/src/wxyz_dvcs/src/wxyz/dvcs/js/src/plugin.ts
+++ b/src/wxyz_dvcs/src/wxyz/dvcs/js/src/plugin.ts
@@ -3,7 +3,7 @@ import { Widget } from '@lumino/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import { NAME, VERSION } from '.';
+import { NAME, VERSION } from './constants';
 import '../style/index.css';
 
 const EXTENSION_ID = `${NAME}:plugin`;

--- a/src/wxyz_dvcs/src/wxyz/dvcs/js/src/widgets/dvcs.ts
+++ b/src/wxyz_dvcs/src/wxyz/dvcs/js/src/widgets/dvcs.ts
@@ -1,6 +1,6 @@
 import * as widgets from '@jupyter-widgets/base';
 
-import { NAME, VERSION } from '..';
+import { NAME, VERSION } from '../constants';
 import { WXYZ } from '@deathbeds/wxyz-core';
 
 export class FooModel extends widgets.DOMWidgetModel {

--- a/src/wxyz_html/src/wxyz/html/js/src/constants.ts
+++ b/src/wxyz_html/src/wxyz/html/js/src/constants.ts
@@ -1,0 +1,4 @@
+import __package__ from '../package.json';
+
+export const NAME = __package__.name;
+export const VERSION = __package__.version;

--- a/src/wxyz_html/src/wxyz/html/js/src/index.ts
+++ b/src/wxyz_html/src/wxyz/html/js/src/index.ts
@@ -1,4 +1,2 @@
-import __package__ from '../package.json';
-
-export const NAME = __package__.name;
-export const VERSION = __package__.version;
+export * from './constants';
+export * from './widgets';

--- a/src/wxyz_html/src/wxyz/html/js/src/plugin.ts
+++ b/src/wxyz_html/src/wxyz/html/js/src/plugin.ts
@@ -3,7 +3,7 @@ import { Widget } from '@lumino/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import { NAME, VERSION } from '.';
+import { NAME, VERSION } from './constants';
 import '../style/index.css';
 
 const EXTENSION_ID = `${NAME}:plugin`;

--- a/src/wxyz_html/src/wxyz/html/js/src/widgets/file.ts
+++ b/src/wxyz_html/src/wxyz/html/js/src/widgets/file.ts
@@ -4,7 +4,7 @@ import * as widgets from '@jupyter-widgets/base';
 import * as controls from '@jupyter-widgets/controls';
 import { JSONExt } from '@lumino/coreutils';
 
-import { NAME, VERSION } from '..';
+import { NAME, VERSION } from '../constants';
 import { WXYZ, WXYZBox, createModel } from '@deathbeds/wxyz-core';
 
 const CSS = {

--- a/src/wxyz_html/src/wxyz/html/js/src/widgets/fullscreen.ts
+++ b/src/wxyz_html/src/wxyz/html/js/src/widgets/fullscreen.ts
@@ -4,7 +4,7 @@ import { Platform } from '@lumino/domutils';
 
 import { BoxModel, BoxView } from '@jupyter-widgets/controls';
 
-import { NAME, VERSION } from '..';
+import { NAME, VERSION } from '../constants';
 
 const FULL_CLASS = 'jp-WXYZ-Fullscreen';
 

--- a/src/wxyz_json_e/src/wxyz/json_e/js/package.json
+++ b/src/wxyz_json_e/src/wxyz/json_e/js/package.json
@@ -48,6 +48,10 @@
       "@deathbeds/wxyz-core": {
         "bundled": false,
         "singleton": true
+      },
+      "codemirror": {
+        "bundled": false,
+        "singleton": true
       }
     }
   },

--- a/src/wxyz_json_e/src/wxyz/json_e/js/src/constants.ts
+++ b/src/wxyz_json_e/src/wxyz/json_e/js/src/constants.ts
@@ -1,0 +1,4 @@
+import __package__ from '../package.json';
+
+export const NAME = __package__.name;
+export const VERSION = __package__.version;

--- a/src/wxyz_json_e/src/wxyz/json_e/js/src/index.ts
+++ b/src/wxyz_json_e/src/wxyz/json_e/js/src/index.ts
@@ -1,4 +1,6 @@
-import __package__ from '../package.json';
+export * from './constants';
+export * from './widgets';
 
-export const NAME = __package__.name;
-export const VERSION = __package__.version;
+export async function loadYamlEMode() {
+  return await import('./modes');
+}

--- a/src/wxyz_json_e/src/wxyz/json_e/js/src/plugin.ts
+++ b/src/wxyz_json_e/src/wxyz/json_e/js/src/plugin.ts
@@ -3,7 +3,7 @@ import { Widget } from '@lumino/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import { NAME, VERSION } from '.';
+import { NAME, VERSION } from './constants';
 import '../style/index.css';
 import './modes';
 

--- a/src/wxyz_jsonld/src/wxyz/jsonld/js/src/constants.ts
+++ b/src/wxyz_jsonld/src/wxyz/jsonld/js/src/constants.ts
@@ -1,0 +1,4 @@
+import __package__ from '../package.json';
+
+export const NAME = __package__.name;
+export const VERSION = __package__.version;

--- a/src/wxyz_jsonld/src/wxyz/jsonld/js/src/index.ts
+++ b/src/wxyz_jsonld/src/wxyz/jsonld/js/src/index.ts
@@ -1,4 +1,1 @@
-import __package__ from '../package.json';
-
-export const NAME = __package__.name;
-export const VERSION = __package__.version;
+export * from './constants';

--- a/src/wxyz_jsonld/src/wxyz/jsonld/js/src/plugin.ts
+++ b/src/wxyz_jsonld/src/wxyz/jsonld/js/src/plugin.ts
@@ -3,7 +3,7 @@ import { Widget } from '@lumino/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import { NAME, VERSION } from '.';
+import { NAME, VERSION } from './constants';
 import '../style/index.css';
 
 const EXTENSION_ID = `${NAME}:plugin`;

--- a/src/wxyz_lab/src/wxyz/lab/js/src/constants.ts
+++ b/src/wxyz_lab/src/wxyz/lab/js/src/constants.ts
@@ -1,0 +1,4 @@
+import __package__ from '../package.json';
+
+export const NAME = __package__.name;
+export const VERSION = __package__.version;

--- a/src/wxyz_lab/src/wxyz/lab/js/src/index.ts
+++ b/src/wxyz_lab/src/wxyz/lab/js/src/index.ts
@@ -1,4 +1,2 @@
-import __package__ from '../package.json';
-
-export const NAME = __package__.name;
-export const VERSION = __package__.version;
+export * from './constants';
+export * from './widgets';

--- a/src/wxyz_lab/src/wxyz/lab/js/src/plugin.ts
+++ b/src/wxyz_lab/src/wxyz/lab/js/src/plugin.ts
@@ -3,7 +3,7 @@ import { Widget } from '@lumino/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import { NAME, VERSION } from '.';
+import { NAME, VERSION } from './constants';
 import '../style/index.css';
 
 const EXTENSION_ID = `${NAME}:plugin`;

--- a/src/wxyz_lab/src/wxyz/lab/js/src/widgets/dock.ts
+++ b/src/wxyz_lab/src/wxyz/lab/js/src/widgets/dock.ts
@@ -6,7 +6,7 @@ import { unpack_models as deserialize } from '@jupyter-widgets/base';
 import { BoxModel, BoxView } from '@jupyter-widgets/controls';
 import { DockLayout } from '@lumino/widgets';
 
-import { NAME, VERSION } from '..';
+import { NAME, VERSION } from '../constants';
 
 import {
   JupyterPhosphorDockPanelWidget,

--- a/src/wxyz_lab/src/wxyz/lab/js/src/widgets/editor.ts
+++ b/src/wxyz_lab/src/wxyz/lab/js/src/widgets/editor.ts
@@ -8,7 +8,7 @@ import {
 import { TextareaModel } from '@jupyter-widgets/controls';
 
 import { WXYZ } from '@deathbeds/wxyz-core';
-import { NAME, VERSION } from '..';
+import { NAME, VERSION } from '../constants';
 
 import { Mode } from '@jupyterlab/codemirror';
 

--- a/src/wxyz_lab/src/wxyz/lab/js/src/widgets/terminal.ts
+++ b/src/wxyz_lab/src/wxyz/lab/js/src/widgets/terminal.ts
@@ -4,7 +4,7 @@ import { DOMWidgetView, DOMWidgetModel } from '@jupyter-widgets/base';
 
 import $ from 'jquery';
 
-import { NAME, VERSION } from '..';
+import { NAME, VERSION } from '../constants';
 
 import { TerminalPhosphorWidget } from './_terminal';
 

--- a/src/wxyz_notebooks/setup.cfg
+++ b/src/wxyz_notebooks/setup.cfg
@@ -76,7 +76,6 @@ thirdparty =
     hvplot
     ipycytoscape
     ipylab
-    jupyterlab-classic
 all =
     %(binder)s
     %(thirdparty)s

--- a/src/wxyz_svg/src/wxyz/svg/js/src/constants.ts
+++ b/src/wxyz_svg/src/wxyz/svg/js/src/constants.ts
@@ -1,0 +1,4 @@
+import __package__ from '../package.json';
+
+export const NAME = __package__.name;
+export const VERSION = __package__.version;

--- a/src/wxyz_svg/src/wxyz/svg/js/src/index.ts
+++ b/src/wxyz_svg/src/wxyz/svg/js/src/index.ts
@@ -1,4 +1,1 @@
-import __package__ from '../package.json';
-
-export const NAME = __package__.name;
-export const VERSION = __package__.version;
+export * from './constants';

--- a/src/wxyz_svg/src/wxyz/svg/js/src/plugin.ts
+++ b/src/wxyz_svg/src/wxyz/svg/js/src/plugin.ts
@@ -3,7 +3,7 @@ import { Widget } from '@lumino/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import { NAME, VERSION } from '.';
+import { NAME, VERSION } from './constants';
 import '../style/index.css';
 
 const EXTENSION_ID = `${NAME}:plugin`;

--- a/src/wxyz_svg/src/wxyz/svg/js/src/widgets/svg.ts
+++ b/src/wxyz_svg/src/wxyz/svg/js/src/widgets/svg.ts
@@ -5,7 +5,7 @@
 import { Widget } from '@lumino/widgets';
 import { DOMWidgetModel } from '@jupyter-widgets/base';
 import { BoxModel, BoxView } from '@jupyter-widgets/controls';
-import { NAME, VERSION } from '..';
+import { NAME, VERSION } from '../constants';
 import * as d3 from 'd3-selection';
 import * as d3Zoom from 'd3-zoom';
 import _ from 'lodash';

--- a/src/wxyz_tpl_jinja/src/wxyz/tpl_jinja/js/src/constants.ts
+++ b/src/wxyz_tpl_jinja/src/wxyz/tpl_jinja/js/src/constants.ts
@@ -1,0 +1,4 @@
+import __package__ from '../package.json';
+
+export const NAME = __package__.name;
+export const VERSION = __package__.version;

--- a/src/wxyz_tpl_jinja/src/wxyz/tpl_jinja/js/src/index.ts
+++ b/src/wxyz_tpl_jinja/src/wxyz/tpl_jinja/js/src/index.ts
@@ -1,4 +1,1 @@
-import __package__ from '../package.json';
-
-export const NAME = __package__.name;
-export const VERSION = __package__.version;
+export * from './constants';

--- a/src/wxyz_tpl_jinja/src/wxyz/tpl_jinja/js/src/plugin.ts
+++ b/src/wxyz_tpl_jinja/src/wxyz/tpl_jinja/js/src/plugin.ts
@@ -3,7 +3,7 @@ import { Widget } from '@lumino/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import { NAME, VERSION } from '.';
+import { NAME, VERSION } from './constants';
 import '../style/index.css';
 
 const EXTENSION_ID = `${NAME}:plugin`;

--- a/src/wxyz_yaml/src/wxyz/yaml/js/src/constants.ts
+++ b/src/wxyz_yaml/src/wxyz/yaml/js/src/constants.ts
@@ -1,0 +1,4 @@
+import __package__ from '../package.json';
+
+export const NAME = __package__.name;
+export const VERSION = __package__.version;

--- a/src/wxyz_yaml/src/wxyz/yaml/js/src/index.ts
+++ b/src/wxyz_yaml/src/wxyz/yaml/js/src/index.ts
@@ -1,4 +1,1 @@
-import __package__ from '../package.json';
-
-export const NAME = __package__.name;
-export const VERSION = __package__.version;
+export * from './constants';

--- a/src/wxyz_yaml/src/wxyz/yaml/js/src/plugin.ts
+++ b/src/wxyz_yaml/src/wxyz/yaml/js/src/plugin.ts
@@ -3,7 +3,7 @@ import { Widget } from '@lumino/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import { NAME, VERSION } from '.';
+import { NAME, VERSION } from './constants';
 import '../style/index.css';
 
 const EXTENSION_ID = `${NAME}:plugin`;


### PR DESCRIPTION
- update to JupyterLab 3.0.5
  - _hard pass_ on nbformat `5.1.0` and `5.1.1`
- uses the `constants` pattern throughout (no importing of a package root from its children)
- hoists all widgets to these boundaries
- tweak some more sharedPackages
- add start of developer documentation to site